### PR TITLE
unescape the escape chars from StringTemplate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,11 @@
 			<version>1.2</version>
 		</dependency>
 		<dependency>
+                          <groupId>commons-lang</groupId>
+                          <artifactId>commons-lang</artifactId>
+                          <version>2.6</version>
+                </dependency>
+		<dependency>
 			<groupId>org</groupId>
 			<artifactId>jnativehook</artifactId>
 			<version>1.1.4</version>

--- a/src/main/java/org/sikuli/slides/api/actions/TypeAction.java
+++ b/src/main/java/org/sikuli/slides/api/actions/TypeAction.java
@@ -6,6 +6,7 @@ import org.sikuli.api.robot.Mouse;
 import org.sikuli.api.robot.desktop.DesktopKeyboard;
 import org.sikuli.api.robot.desktop.DesktopMouse;
 import org.sikuli.slides.api.Context;
+import org.apache.commons.lang.StringEscapeUtils;
 
 import com.google.common.base.Objects;
 
@@ -24,6 +25,7 @@ public class TypeAction extends AbstractAction {
 	@Override
 	protected void doExecute(Context context) {
 		String textToType = context.render(getText());
+		textToType = StringEscapeUtils.unescapeJava(textToType);
 		ScreenRegion screenRegion = context.getScreenRegion();
 		Mouse mouse = new DesktopMouse();
 		Keyboard keyboard=new DesktopKeyboard();


### PR DESCRIPTION
StringTemplate escapes any escape chars so \n becomes \n. This removes functionality from Sikuli slides type command especially when interacting with the CLI or tabs.
